### PR TITLE
Fix typo: initalize -> initialize

### DIFF
--- a/lib/cryptomnio.rb
+++ b/lib/cryptomnio.rb
@@ -51,7 +51,7 @@ end
 
 # HTTPClient Class Wrapper
 class HTTPClient
-	def initalize(client = RestClient)
+	def initialize(client = RestClient)
 		@client = client
 	end
 
@@ -73,8 +73,8 @@ class Cryptomnio::REST < Cryptomnio
 	# If "http_proxy" is set in the program's environment, it will be used for
 	# the RestClient's proxy setting.
 
-	def initalize
-		# Call Superlcass initialize
+	def initialize
+		# Call Superclass initialize
 		super
 
 		# Get the HTTP proxy from the environment (if there is one)


### PR DESCRIPTION
Fixes the  typo in two class constructors:

-  (lib/cryptomnio.rb:54)
-  (lib/cryptomnio.rb:76)

Because Ruby only treats a method literally named  as the constructor, both method bodies were silently dead code. The most user-visible consequence:  reads  and applies it to , so any user relying on the  env var to route Cryptomnio API traffic through a proxy was silently bypassed.

Also fixes the  typo in the corrected method's comment.

Total change: 3 lines, all in .

Closes #4